### PR TITLE
1. Luccas/contextualize exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Middleware Configuration Options:
   - `header_name`: Custom header name for request ID (default: X-Request-ID)
 - BaseApi Configuration
   - `request_id_header_name`: Header name for request ID propagation (default: X-Request-ID)
+  - `context_keys`: List of keys that should be searched in the request body and added to the logger context when the exception is reported (eg: `["orderId", "kitId"]`). The key will be converted to snake case when added to the logger context.
 
 
 ### Error Handling
@@ -260,8 +261,8 @@ create_support_ticket("Problem with kit processing", ticket)
 
 # Or with a different log level
 create_support_ticket(
-    message="Non-critical issue with kit", 
-    ticket_data=ticket, 
+    message="Non-critical issue with kit",
+    ticket_data=ticket,
     log_level=LogLevel.WARNING
 )
 ```

--- a/ash_utils/middlewares/catch_unexpected_exception.py
+++ b/ash_utils/middlewares/catch_unexpected_exception.py
@@ -1,3 +1,6 @@
+import re
+from typing import cast
+
 from fastapi import Request, status
 from fastapi.responses import JSONResponse
 from loguru import logger
@@ -10,10 +13,12 @@ class CatchUnexpectedExceptionsMiddleware:
         app: ASGIApp,
         response_error_message: str,
         response_status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR,
+        context_keys: list[str] | None = None,
     ):
         self.app = app
         self.response_error_message = response_error_message
         self.response_status_code = response_status_code
+        self.context_keys = context_keys or []
 
     async def __call__(self, scope, receive, send):
         if scope["type"] != "http":  # pragma: no cover
@@ -21,13 +26,81 @@ class CatchUnexpectedExceptionsMiddleware:
             return
 
         request = Request(scope, receive)
+
         try:
             await self.app(scope, receive, send)
         except Exception:
-            logger.exception(f"Unexpected exception. Url: {request.url}")
+            context = await self._extract_request_info(request)
+            with logger.contextualize(**context):
+                logger.exception(f"Unexpected exception. Url: {request.url}")
             response = JSONResponse(
                 status_code=self.response_status_code,
                 content={"detail": self.response_error_message},
             )
             await response(scope, receive, send)
             return
+
+    async def _extract_request_info(self, request: Request) -> dict[str, str]:
+        """
+        Extracts specified keys from the request data or query parameters.
+
+        Args:
+            request: The incoming request object.
+
+        Returns:
+            A dictionary containing the extracted key-value pairs.
+        """
+        try:
+            data = await request.json()
+        except Exception:
+            data = cast(dict, request.query_params)
+
+        context = {}
+        for key in self.context_keys:
+            value = _find_key_in_dict(data, key)
+            if value is not None:
+                context[_to_snake(key)] = value
+        return context
+
+
+def _find_key_in_dict(data: dict, key: str) -> str | None:
+    """
+    Finds the value of a specified key in a nested dictionary.
+
+    Args:
+        data: The dictionary to search.
+        key: The key to find.
+
+    Returns:
+        The value associated with the key, or None if not found.
+    """
+    if key in data:
+        return data[key]
+    for value in data.values():
+        if isinstance(value, dict):
+            found = _find_key_in_dict(value, key)
+            if found is not None:
+                return found
+    return None
+
+
+def _to_snake(camel: str) -> str:
+    """Convert a PascalCase, camelCase, or kebab-case string to snake_case.
+
+    Args:
+        camel: The string to convert.
+
+    Returns:
+        The converted string in snake_case.
+    """
+    # Handle the sequence of uppercase letters followed by a lowercase letter
+    snake = re.sub(r"([A-Z]+)([A-Z][a-z])", lambda m: f"{m.group(1)}_{m.group(2)}", camel)
+    # Insert an underscore between a lowercase letter and an uppercase letter
+    snake = re.sub(r"([a-z])([A-Z])", lambda m: f"{m.group(1)}_{m.group(2)}", snake)
+    # Insert an underscore between a digit and an uppercase letter
+    snake = re.sub(r"([0-9])([A-Z])", lambda m: f"{m.group(1)}_{m.group(2)}", snake)
+    # Insert an underscore between a lowercase letter and a digit
+    snake = re.sub(r"([a-z])([0-9])", lambda m: f"{m.group(1)}_{m.group(2)}", snake)
+    # Replace hyphens with underscores to handle kebab-case
+    snake = snake.replace("-", "_")
+    return snake.lower()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ashwelness-utils"
-version = "0.2.0"
+version = "0.1.4"
 description = "Python library containing common utilities used across various ASH projects."
 readme = "README.md"
 requires-python = ">=3.11,<4.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,4 +20,8 @@ def app():
     async def root():
         raise Exception
 
+    @app.post("/error-json")
+    async def root():
+        raise Exception
+
     return app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from loguru import logger
 
 
@@ -21,7 +21,9 @@ def app():
         raise Exception
 
     @app.post("/error-json")
-    async def root():
+    async def root(request: Request, read_body: bool = False):
+        if read_body:
+            await request.json()
         raise Exception
 
     return app

--- a/tests/middlewears/test_catch_unexpected_exception_middleware.py
+++ b/tests/middlewears/test_catch_unexpected_exception_middleware.py
@@ -1,10 +1,14 @@
+from unittest.mock import patch
+
 from ash_utils.middlewares import CatchUnexpectedExceptionsMiddleware
 from fastapi.testclient import TestClient
 
 
 def test__catch_unexpected_exception__default_params__success(app):
     error_message = "Internal error"
-    app.add_middleware(CatchUnexpectedExceptionsMiddleware, response_error_message=error_message)
+    app.add_middleware(
+        CatchUnexpectedExceptionsMiddleware, response_error_message=error_message, context_keys=["nothing"]
+    )
 
     resp = TestClient(app, raise_server_exceptions=False).get("/error")
 
@@ -19,9 +23,30 @@ def test__catch_unexpected_exception__success(app):
         CatchUnexpectedExceptionsMiddleware,
         response_status_code=status_code,
         response_error_message=error_message,
+        context_keys=["myParam"],
     )
 
-    resp = TestClient(app, raise_server_exceptions=False).get("/error")
+    with patch("ash_utils.middlewares.catch_unexpected_exception.logger.contextualize") as mock_contextualize:
+        resp = TestClient(app, raise_server_exceptions=False).get("/error", params={"myParam": "value"})
+        mock_contextualize.assert_called_once_with(my_param="value")
+
+    assert resp.status_code == status_code
+    assert resp.json() == {"detail": error_message}
+
+
+def test__catch_unexpected_exception__context_data__success(app):
+    error_message = "Internal error"
+    status_code = 400
+    app.add_middleware(
+        CatchUnexpectedExceptionsMiddleware,
+        response_status_code=status_code,
+        response_error_message=error_message,
+        context_keys=["nested"],
+    )
+
+    with patch("ash_utils.middlewares.catch_unexpected_exception.logger.contextualize") as mock_contextualize:
+        resp = TestClient(app, raise_server_exceptions=False).post("/error-json", json={"key": {"nested": "value"}})
+        mock_contextualize.assert_called_once_with(nested="value")
 
     assert resp.status_code == status_code
     assert resp.json() == {"detail": error_message}


### PR DESCRIPTION
## Change Summary

This change is related to the work being done to clean up Sentry error messages.

- This PR modifies the `CatchUnexpectedExceptionsMiddleware` so that a new `context_keys` parameter can be passed. 
- This parameter is a list of keys that should be extracted from the request body and added to the logger context when an exception is reported. 
- The goal is to allow values like the `kit_id` or `order_id` to be automatically included in the context (if present in the request) so that they can be added to the Sentry error message.
- This change is necessary because even if the exception was raised inside a `logger.contextualize` block, the logger context is cleared by the time the middleware catches the exception.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactor (changes code structure with same or similar functionality)
- [ ] Libs update (Libs update with code change or with minor code change to get new version working)

## Checklists

### Development

- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass
- [x] The README file is updated if needed

### Security

- [ ] Security impact of change has been considered
- [ ] New endpoints that should be protected have been registered in Auth services

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
